### PR TITLE
Fix #79 thresholds color legend

### DIFF
--- a/src/worldmap.js
+++ b/src/worldmap.js
@@ -48,7 +48,7 @@ export default class WorldMap {
           '&lt; ' + thresholds[0] + '<br>';
       for (let index = 0; index < thresholds.length; index += 1) {
         legendHtml +=
-          '<i style="background:' + this.getColor(thresholds[index] + 1) + '"></i> ' +
+          '<i style="background:' + this.ctrl.panel.colors[index+1] + '"></i> ' +
           thresholds[index] + (thresholds[index + 1] ? '&ndash;' + thresholds[index + 1] + '<br>' : '+');
       }
       this.legend._div.innerHTML = legendHtml;


### PR DESCRIPTION
There is actually a problem on the Leaftlet colors legend when using float numbers as thresholds.

![image](https://user-images.githubusercontent.com/496277/31547921-67514a44-b029-11e7-81c8-f0e0a411766c.png)

Regarding this screenshot the third threshold color should be green. Instead it takes the same color than the last threshold.

This behavior is caused by the following line https://github.com/grafana/worldmap-panel/blob/master/src/worldmap.js#L51

We can fix it by using directly the colors array at the thresholds index.

Fixes #79
