### PR TITLE
Add Clickthrough URL option for country circles

### DIFF
--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -28,6 +28,10 @@
       checked="ctrl.panel.stickyLabels" on-change="ctrl.toggleStickyLabels()">
     </gf-form-switch>
 		<div class="gf-form">
+			<label class="gf-form-label width-10">Clickthrough URL</label>
+			<input type="text" class="input-small gf-form-input width-10" ng-model="ctrl.panel.clickthroughURL" ng-change="ctrl.refresh()" ng-model-onblur />
+		</div>
+		<div class="gf-form">
 			<label class="gf-form-label width-10">Decimals</label>
 			<input type="number" class="input-small gf-form-input width-10" ng-model="ctrl.panel.decimals" ng-change="ctrl.refresh()" ng-model-onblur />
 		</div>

--- a/src/worldmap.js
+++ b/src/worldmap.js
@@ -114,6 +114,7 @@ export default class WorldMap {
           location: dataPoint.key,
         });
         circle.unbindPopup();
+        this.createClickthrough(circle, dataPoint.key);
         this.createPopup(circle, dataPoint.locationName, dataPoint.valueRounded);
       }
     });
@@ -128,6 +129,7 @@ export default class WorldMap {
       location: dataPoint.key
     });
 
+    this.createClickthrough(circle, dataPoint.key);
     this.createPopup(circle, dataPoint.locationName, dataPoint.valueRounded);
     return circle;
   }
@@ -160,6 +162,15 @@ export default class WorldMap {
     if (!this.ctrl.panel.stickyLabels) {
       circle.on('mouseout', function onMouseOut() {
         circle.closePopup();
+      });
+    }
+  }
+
+  createClickthrough(circle, key) {
+    if (this.ctrl.panel.clickthroughURL) {
+      const newURL = this.ctrl.panel.clickthroughURL.replace('$country', key);
+      circle.on('click', function onClick(evt) {
+        window.location.assign(newURL);
       });
     }
   }

--- a/src/worldmap_ctrl.js
+++ b/src/worldmap_ctrl.js
@@ -27,7 +27,8 @@ const panelDefaults = {
   decimals: 0,
   hideEmpty: false,
   hideZero: false,
-  stickyLabels: false
+  stickyLabels: false,
+  clickthroughURL: ''
 };
 
 const mapCenters = {


### PR DESCRIPTION
This is a simple implementation of a panel option being used to navigate to a new URL on click.

Instances of `$country` in the clickthrough URL will be replaced with the selected country. In fact this should work regardless of location data type, so perhaps "country" is not the most appropriate keyword.

See #62 and #121.