### PR TITLE
Use latitude and longitude if given in table data

### DIFF
--- a/src/data_formatter.js
+++ b/src/data_formatter.js
@@ -143,18 +143,25 @@ export default class DataFormatter {
       let lowestValue = Number.MAX_VALUE;
 
       tableData[0].forEach((datapoint) => {
-        if (!datapoint.geohash) {
-          return;
+        let latitude = datapoint.latitude;
+        let longitude = datapoint.longitude;
+        let key = `${latitude}_${longitude}`;
+
+        if (datapoint.geohash) {
+          const encodedGeohash = datapoint.geohash;
+          const decodedGeohash = decodeGeoHash(encodedGeohash);
+
+          latitude = decodedGeohash.latitude;
+          longitude = decodedGeohash.longitude;
+
+          key = encodedGeohash;
         }
 
-        const encodedGeohash = datapoint.geohash;
-        const decodedGeohash = decodeGeoHash(encodedGeohash);
-
         const dataValue = {
-          key: encodedGeohash,
+          key: key,
           locationName: datapoint[this.ctrl.panel.tableLabel] || 'n/a',
-          locationLatitude: decodedGeohash.latitude,
-          locationLongitude: decodedGeohash.longitude,
+          locationLatitude: latitude,
+          locationLongitude: longitude,
           value: datapoint.metric,
           valueFormatted: datapoint.metric,
           valueRounded: 0
@@ -198,4 +205,3 @@ export default class DataFormatter {
     }
   }
 }
-

--- a/test/data_formatter_test.js
+++ b/test/data_formatter_test.js
@@ -5,6 +5,63 @@ describe('DataFormatter', () => {
   let dataFormatter;
   let formattedData = [];
 
+  describe('when latitude and longitude are given in table data', () => {
+    beforeEach(() => {
+      const ctrl = {
+        panel: {}
+      };
+      dataFormatter = new DataFormatter(ctrl, {roundValue: () => {}});
+    });
+
+    it('should use latitude and longitude if no geohash is given', () => {
+      const tableData = [
+        [
+          {
+            latitude: 1,
+            longitude: 2
+          },
+          {
+            latitude: 3,
+            longitude: 4
+          }
+        ]
+      ];
+      const data = [];
+
+      dataFormatter.setTableValues(tableData, data);
+
+      expect(data[0].locationLatitude).to.equal(1);
+      expect(data[0].locationLongitude).to.equal(2);
+      expect(data[1].locationLatitude).to.equal(3);
+      expect(data[1].locationLongitude).to.equal(4);
+    });
+
+    it('should prefer geohash if given', () => {
+      const tableData = [
+        [
+          {
+            latitude: 1,
+            longitude: 2,
+            geohash: 'stq4s3x' // 29.9796, 31.1345
+          },
+          {
+            latitude: 3,
+            longitude: 4,
+            geohash: 'p05010r' // -89.997, 139.273
+          }
+        ]
+      ];
+      const data = [];
+
+      dataFormatter.setTableValues(tableData, data);
+
+      expect(data[0].locationLatitude).to.be.within(29.9796, 29.9797);
+      expect(data[0].locationLongitude).to.be.within(31.1345, 31.1346);
+      expect(data[1].locationLatitude).to.be.within(-89.998, -89.997);
+      expect(data[1].locationLongitude).to.be.within(139.272, 139.273);
+    });
+  });
+
   describe('when the time series data matches the location', () => {
     beforeEach(() => {
       const ctrl = {


### PR DESCRIPTION
I've seen a couple issues open for this, and in one of them, you mentioned you'd accept a pull request for this feature. I took a stab at it, and got it working in a local grafana instance that's connected to an influxdb data source with some location data in the form of lat and lon. There was no good place in my pipeline to convert these points to geohash before inserting them into my database, and I figured it would just be nice if this plugin supported rendering latitude and longitude points as well as geohash points.

When reading and formatting table data only, it will look for `latitude` and `longitude` specified in the datapoint and use those. If a `geohash` is provided, then that will override any given latitude and longitude. There is a unit test to show this working.

![2018-06-10-144945_1122x1120_escrotum](https://user-images.githubusercontent.com/298171/41206729-7e0080ec-6cbd-11e8-95ca-998e51ec5074.png)
