### PR TITLE
Fixed wrong centering when loading panel

### DIFF
--- a/src/worldmap.js
+++ b/src/worldmap.js
@@ -19,10 +19,7 @@ export default class WorldMap {
 
   createMap() {
     const mapCenter = window.L.latLng(parseFloat(this.ctrl.panel.mapCenterLatitude), parseFloat(this.ctrl.panel.mapCenterLongitude));
-    this.map = window.L.map(this.mapContainer, {worldCopyJump: true, center: mapCenter})
-      .fitWorld()
-      .zoomIn(parseInt(this.ctrl.panel.initialZoom, 10));
-    this.map.panTo(mapCenter);
+    this.map = window.L.map(this.mapContainer, { worldCopyJump: true, center: mapCenter, zoom: (this.panel.initialZoom || 1) });
     this.setMouseWheelZoom();
 
     const selectedTileServer = tileServers[this.ctrl.tileServer];


### PR DESCRIPTION
Correct usage of options to set zoom with the center to avoid recentering to 0,0 when loading panel.
When applying a zoom after creating the map, the zoom overrides the provided center in the options and makes the map zoom on 0,0 ignoring the individual center defined in the options.
Fixes #149 