### PR TITLE
Update Basemaps URL and attributions

### DIFF
--- a/src/worldmap.test.ts
+++ b/src/worldmap.test.ts
@@ -329,7 +329,7 @@ describe('Worldmap', () => {
         initialZoom: 1,
         colors: ['red', 'blue', 'green'],
       },
-      tileServer: 'CartoDB Positron',
+      tileServer: 'CARTO Positron',
     };
     worldMap = new WorldMap(ctrl, document.getElementsByClassName('mapcontainer')[0]);
     worldMap.createMap();

--- a/src/worldmap.ts
+++ b/src/worldmap.ts
@@ -3,18 +3,18 @@ import * as L from './libs/leaflet';
 import WorldmapCtrl from './worldmap_ctrl';
 
 const tileServers = {
-  'CartoDB Positron': {
-    url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+  'CARTO Positron': {
+    url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
     attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
+      '&copy; <a href="https://carto.com/about-carto/">CARTO</a>',
     subdomains: 'abcd',
   },
-  'CartoDB Dark': {
-    url: 'https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png',
+  'CARTO Dark': {
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',
     attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
-      '&copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> ' +
+      '&copy; <a href="https://carto.com/about-carto/">CARTO</a>',
     subdomains: 'abcd',
   },
 };

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -83,13 +83,13 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
 
   setMapProvider(contextSrv) {
     this.tileServer = contextSrv.user.lightTheme
-      ? "CartoDB Positron"
-      : "CartoDB Dark";
+      ? "CARTO Positron"
+      : "CARTO Dark";
     this.setMapSaturationClass();
   }
 
   setMapSaturationClass() {
-    if (this.tileServer === "CartoDB Dark") {
+    if (this.tileServer === "CARTO Dark") {
       this.saturationClass = "map-darken";
     } else {
       this.saturationClass = "";


### PR DESCRIPTION
# Summary
This PR updates basemaps URL to the new CDN URL and fixes the attributions to match current requirements. It also changes our old name from `CartoDB` to `CARTO` (although looks that basemaps names are internal and not exposed to the user, we could skip this if has any kind of side-effects on existing basemaps and just change URL and Attributions).

## Full context
We've recently changed our CDN and we have a plan mid-long term (depends on how quick we manage to stop all the traffic there) to deprecate our `.global.ssl.fastly.net` domains.

Reviewing the history of this project at some point it used the `*.basemaps.cartocdn.com` endpoints but were changed because of the lack of HTTPS, which is not an issue anymore.

# Additional stuff
Just as a suggestion I'd add to the attributions `<a>` properties ` target="_blank" rel="noopener"`, this way if a user clicks on it doesn't close the Grafana dashboard but opens it in a new tab.