### PR TITLE
Add geomap migration button to options menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,10 @@
 
 ## Entries
 
-## v1.0.5
-
-- Add Geomap migration warning and button to options menu
-
 ## v1.0.4
 
 - Validate legend colors
+- Add Geomap migration warning and button to options menu
 
 ## v1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
+
 ## Entries
+
+## v1.0.5
+
+- Add Geomap migration warning and button to options menu
 
 ## v1.0.4
 
 - Validate legend colors
-
 
 ## v1.0.3
 

--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -5,6 +5,13 @@
       <p>
         Consider switching to the <a href="https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/" target="_blank">Geomap</a> visualization type. It is a more capable and performant version of this panel.
       </p>
+      <ul>
+        <li>Multiple layers with opacity</li>
+        <li>Multiple basemap options, that can also be layered</li>
+        <li>More viewport options, including real time data fit</li>
+        <li>Markers, Heatmap, GeoJSON, CARTO, XYZ, OSM, ArcGIS, Night / Day, Routes, Photos, and more...</li>
+      </ul>
+      <br>
       <p>
         <button class="btn btn-primary" ng-click="ctrl.migrateToReact()">
           Migrate

--- a/src/partials/editor.html
+++ b/src/partials/editor.html
@@ -1,5 +1,17 @@
 <div class="editor-row">
   <div class="section gf-form-group">
+    <div class="grafana-info-box">
+      <h5>Migration</h5>
+      <p>
+        Consider switching to the <a href="https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/geomap/" target="_blank">Geomap</a> visualization type. It is a more capable and performant version of this panel.
+      </p>
+      <p>
+        <button class="btn btn-primary" ng-click="ctrl.migrateToReact()">
+          Migrate
+        </button>
+      </p>
+    </div>
+
     <h5 class="section-heading">Map Visual Options</h5>
     <div class="gf-form">
       <label class="gf-form-label width-10">Center</label>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,7 +4,7 @@
   "id": "grafana-worldmap-panel",
 
   "info": {
-    "description": "World Map panel for Grafana. Displays time series data or geohash data from Elasticsearch overlaid on a world map.",
+    "description": "This panel is deprecated and will no longer be supported. Please use Geomap instead. World Map panel for Grafana. Displays time series data or geohash data from Elasticsearch overlaid on a world map.",
     "author": {
       "name": "Grafana Labs",
       "url": "https://grafana.com"
@@ -23,8 +23,8 @@
       {"name": "USA", "path": "images/worldmap-usa.png"},
       {"name": "Light Theme", "path": "images/worldmap-light-theme.png"}
     ],
-    "version": "1.0.3",
-    "updated": "Tue Feb 07 14:29:24 EDT 2023"
+    "version": "1.0.5",
+    "updated": "Thu Jun 10 00:00:00 EDT 2023"
   },
 
   "dependencies": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -23,8 +23,8 @@
       {"name": "USA", "path": "images/worldmap-usa.png"},
       {"name": "Light Theme", "path": "images/worldmap-light-theme.png"}
     ],
-    "version": "1.0.5",
-    "updated": "Thu Jun 10 00:00:00 EDT 2023"
+    "version": "1.0.3",
+    "updated": "Tue Feb 07 14:29:24 EDT 2023"
   },
 
   "dependencies": {

--- a/src/worldmap_ctrl.ts
+++ b/src/worldmap_ctrl.ts
@@ -1,5 +1,6 @@
 import { MetricsPanelCtrl } from 'grafana/app/plugins/sdk';
 import { PanelEvents, textUtil } from '@grafana/data';
+import config from 'grafana/app/core/config';
 
 import TimeSeries from 'grafana/app/core/time_series2';
 // import appEvents from "grafana/app/core/app_events";
@@ -341,5 +342,9 @@ export default class WorldmapCtrl extends MetricsPanelCtrl {
 
       ctrl.map.drawCircles();
     }
+  }
+
+  migrateToReact() {
+    this.onPluginTypeChange(config.panels['geomap']);
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:
To help push for migration towards Geomap, we need to get the message out that auto migration is an option in Worldmap.

Before:
![image](https://github.com/grafana/worldmap-panel/assets/60050885/5e221230-45a8-41d2-8d46-1ed08c03bdb7)

After:
![Jun-08-2023 11-04-57](https://github.com/grafana/worldmap-panel/assets/60050885/9b43721b-6be6-496b-a147-43b78c3a8b01)
