### PR TITLE
prep release for v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Entries
 
-## v1.0.5
+## v1.0.6
 
 - Fixes CSS path issue, thanks @jackw!
+- Includes changes from v1.0.5 that were not published
+
+## v1.0.5
+
+- Not published
 
 ## v1.0.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldmap-panel",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Worldmap Panel Plugin for Grafana",
   "main": "src/module.js",
   "scripts": {

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -23,8 +23,8 @@
       {"name": "USA", "path": "images/worldmap-usa.png"},
       {"name": "Light Theme", "path": "images/worldmap-light-theme.png"}
     ],
-    "version": "1.0.3",
-    "updated": "Tue Feb 07 14:29:24 EDT 2023"
+    "version": "%VERSION%",
+    "updated": "%TODAY%"
   },
 
   "dependencies": {


### PR DESCRIPTION
There is an unpublished v1.0.5, skipping to 1.0.6 to prevent any conflicts.

- updated src/plugin.json to let toolkit update version and date from package.json
- update changelog
- set version to 1.0.6